### PR TITLE
Fix NPE if the return value of BlockItem#getBlock is null

### DIFF
--- a/src/main/java/com/github/kuramastone/cobblemonChallenges/events/BlockPlaceEvent.java
+++ b/src/main/java/com/github/kuramastone/cobblemonChallenges/events/BlockPlaceEvent.java
@@ -9,6 +9,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 
@@ -50,9 +51,9 @@ public class BlockPlaceEvent {
         try {
             if (!level.isClientSide) {
                 ItemStack stack = player.getItemInHand(interactionHand);
-                if (!stack.isEmpty() && stack.getItem() instanceof BlockItem blockItem) {
+                if (!stack.isEmpty() && stack.getItem() instanceof BlockItem blockItem && blockItem.getBlock() instanceof Block block) {
                     BlockPos placePos = blockHitResult.getBlockPos().relative(blockHitResult.getDirection());
-                    BlockState stateToPlace = blockItem.getBlock().defaultBlockState();
+                    BlockState stateToPlace = block.defaultBlockState();
 
                     ChallengeListener.onBlockPlace(
                         new BlockPlaceEvent(stateToPlace, placePos, level, player)


### PR DESCRIPTION
I've got this NPE in a server I'm working in:

```
[19:42:05] [Server thread/INFO]: [STDERR]: java.lang.NullPointerException: Cannot invoke "net.minecraft.world.level.block.Block.defaultBlockState()" because the return value of "net.minecraft.world.item.BlockItem.getBlock()" is null
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//com.github.kuramastone.cobblemonChallenges.events.BlockPlaceEvent.trigger(BlockPlaceEvent.java:55)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.fabricmc.fabric.api.event.player.UseBlockCallback.lambda$static$0(UseBlockCallback.java:41)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.level.ServerPlayerGameMode.handler$zpm000$fabric-events-interaction-v0$interactBlock(ServerPlayerGameMode.java:1087)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.level.ServerPlayerGameMode.useItemOn(ServerPlayerGameMode.java)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.network.ServerGamePacketListenerImpl.redirect$blf000$griefdefender$onHandleUseItemOn(ServerGamePacketListenerImpl.java:7566)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.network.ServerGamePacketListenerImpl.handleUseItemOn(ServerGamePacketListenerImpl.java:1158)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.handle(ServerboundUseItemOnPacket.java:42)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.handle(ServerboundUseItemOnPacket.java:10)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:27)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.TickTask.run(TickTask.java:18)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:162)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:23)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:864)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:173)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:136)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:846)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:840)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:145)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:810)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:815)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:702)
[19:42:05] [Server thread/INFO]: [STDERR]:      at knot//net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:281)
[19:42:05] [Server thread/INFO]: [STDERR]:      at java.base/java.lang.Thread.run(Thread.java:1583)
[19:42:05] [Server thread/ERROR]: Failed to handle packet net.minecraft.network.protocol.game.ServerboundUseItemOnPacket@23542f8b, suppressing error
java.lang.NullPointerException: Cannot invoke "net.minecraft.block.Block.getDefaultState()" because the return value of "net.minecraft.item.BlockItem.getBlock()" is null
        at knot/com.github.kuramastone.cobblemonChallenges.events.BlockPlaceEvent.trigger(BlockPlaceEvent.java:55) ~[CobblemonChallenges-1.2.2.jar:?]
        at knot/net.fabricmc.fabric.api.event.player.UseBlockCallback.lambda$static$0(UseBlockCallback.java:41) ~[fabric-events-interaction-v0-0.7+ba9dae0619-656dbfb5b8cce5ac.jar:?]
        at knot//MC/net.minecraft.server.network.ServerPlayerInteractionManager.handler$zpm000$fabric-events-interaction-v0$interactBlock(ServerPlayerInteractionManager.java:1087) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.server.network.ServerPlayerInteractionManager.interactBlock(ServerPlayerInteractionManager.java) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.server.network.ServerPlayNetworkHandler.redirect$blf000$griefdefender$onHandleUseItemOn(ServerPlayNetworkHandler.java:7566) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.server.network.ServerPlayNetworkHandler.onPlayerInteractBlock(ServerPlayNetworkHandler.java:1158) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket.apply(PlayerInteractBlockC2SPacket.java:42) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket.apply(PlayerInteractBlockC2SPacket.java:10) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.network.NetworkThreadUtils.lambda$ensureRunningOnSameThread$0(NetworkThreadUtils.java:27) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.server.ServerTask.run(ServerTask.java:18) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.util.thread.ThreadExecutor.executeTask(ThreadExecutor.java:162) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.util.thread.ReentrantThreadExecutor.executeTask(ReentrantThreadExecutor.java:23) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.executeTask(MinecraftServer.java:864) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.executeTask(MinecraftServer.java:173) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.util.thread.ThreadExecutor.runTask(ThreadExecutor.java:136) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.runOneTask(MinecraftServer.java:846) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.runTask(MinecraftServer.java:840) ~[server-intermediary.jar:?]
        at knot//MC/net.minecraft.util.thread.ThreadExecutor.runTasks(ThreadExecutor.java:145) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.runTasks(MinecraftServer.java:810) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.runTasksTillTickEnd(MinecraftServer.java:815) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:702) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:281) ~[server-intermediary.jar:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```

Checking if the return value of ``BlockItem#getBlock`` is an instance of Block also counts as a null check, so that's why I'm making this PR.